### PR TITLE
Added SeqBRNN support

### DIFF
--- a/SeqBRNN.lua
+++ b/SeqBRNN.lua
@@ -1,0 +1,78 @@
+------------------------------------------------------------------------
+--[[ BRNN ]] --
+-- Bi-directional RNN using two SeqLSTM modules.
+-- Input is a tensor e.g batch x time x inputdim.
+-- Output is a tensor of the same length e.g batch x time x outputdim.
+-- Applies a forward rnn to input tensor in forward order
+-- and applies a backward rnn in reverse order.
+-- Reversal of the sequence happens on the time dimension.
+-- For each step, the outputs of both rnn are merged together using
+-- the merge module (defaults to nn.CAddTable() which sums the activations).
+------------------------------------------------------------------------
+local SeqBRNN, parent = torch.class('nn.SeqBRNN', 'nn.Container')
+
+function SeqBRNN:__init(inputDim, hiddenDim, batchFirst, merge)
+    self.forwardModule = nn.SeqLSTM(inputDim, hiddenDim)
+    self.backwardModule = nn.SeqLSTM(inputDim, hiddenDim)
+    self.merge = merge
+    if not self.merge then
+        self.merge = nn.CAddTable()
+    end
+    if batchFirst then
+        self.forwardModule.batchFirst = true
+        self.backwardModule.batchFirst = true
+        self.dim = 2 -- default to second dimension to reverse (expecting batch x time x inputdim).
+    else
+        self.dim = 1 -- first dim to reverse (expecting time x batch x inputdim).
+    end
+    local backward = nn.Sequential()
+    backward:add(nn.SeqReverseSequence(self.dim)) -- reverse
+    backward:add(self.backwardModule)
+    backward:add(nn.SeqReverseSequence(self.dim)) -- unreverse
+
+    local concat = nn.ConcatTable()
+    concat:add(self.forwardModule):add(backward)
+
+    local brnn = nn.Sequential()
+    brnn:add(concat)
+    brnn:add(self.merge)
+
+    parent.__init(self)
+
+    self.output = torch.Tensor()
+    self.gradInput = torch.Tensor()
+
+    self.module = brnn
+    -- so that it can be handled like a Container
+    self.modules[1] = brnn
+end
+
+function SeqBRNN:updateOutput(input)
+    self.output = self.module:updateOutput(input)
+    return self.output
+end
+
+function SeqBRNN:updateGradInput(input, gradOutput)
+    self.gradInput = self.module:updateGradInput(input, gradOutput)
+    return self.gradInput
+end
+
+function SeqBRNN:accGradParameters(input, gradOutput, scale)
+    self.module:accGradParameters(input, gradOutput, scale)
+end
+
+function SeqBRNN:accUpdateGradParameters(input, gradOutput, lr)
+    self.module:accUpdateGradParameters(input, gradOutput, lr)
+end
+
+function SeqBRNN:sharedAccUpdateGradParameters(input, gradOutput, lr)
+    self.module:sharedAccUpdateGradParameters(input, gradOutput, lr)
+end
+
+function SeqBRNN:__tostring__()
+    if self.module.__tostring__ then
+        return torch.type(self) .. ' @ ' .. self.module:__tostring__()
+    else
+        return torch.type(self) .. ' @ ' .. torch.type(self.module)
+    end
+end

--- a/SeqBRNN.lua
+++ b/SeqBRNN.lua
@@ -18,13 +18,7 @@ function SeqBRNN:__init(inputDim, hiddenDim, batchFirst, merge)
     if not self.merge then
         self.merge = nn.CAddTable()
     end
-    if batchFirst then
-        self.forwardModule.batchFirst = true
-        self.backwardModule.batchFirst = true
-        self.dim = 2 -- default to second dimension to reverse (expecting batch x time x inputdim).
-    else
-        self.dim = 1 -- first dim to reverse (expecting time x batch x inputdim).
-    end
+    self.dim = 1
     local backward = nn.Sequential()
     backward:add(nn.SeqReverseSequence(self.dim)) -- reverse
     backward:add(self.backwardModule)
@@ -36,6 +30,11 @@ function SeqBRNN:__init(inputDim, hiddenDim, batchFirst, merge)
     local brnn = nn.Sequential()
     brnn:add(concat)
     brnn:add(self.merge)
+    if(batchFirst) then
+        -- Insert transposes before and after the brnn.
+        brnn:insert(nn.Transpose({1, 2}), 1)
+        brnn:insert(nn.Transpose({1, 2}))
+    end
 
     parent.__init(self)
 

--- a/SeqReverseSequence.lua
+++ b/SeqReverseSequence.lua
@@ -1,0 +1,72 @@
+------------------------------------------------------------------------
+--[[ SeqReverseSequence ]] --
+-- Reverses a sequence on a given dimension.
+-- Example: Given a tensor of torch.Tensor({{1,2,3,4,5}, {6,7,8,9,10})
+-- nn.ReverseSequence(1):forward(tensor) would give: torch.Tensor({{6,7,8,9,10},{1,2,3,4,5}})
+------------------------------------------------------------------------
+local SeqReverseSequence, parent = torch.class("nn.SeqReverseSequence", "nn.Module")
+
+function SeqReverseSequence:__init(dim)
+    parent.__init(self)
+    self.output = torch.Tensor()
+    self.gradInput = torch.Tensor()
+    self.outputIndices = torch.LongTensor()
+    self.gradIndices = torch.LongTensor()
+    assert(dim, "Must specify dimension to reverse sequence over")
+    assert(dim <= 3, "Dimension has to be no greater than 3 (Only supports up to a 3D Tensor).")
+    self.dim = dim
+end
+
+function SeqReverseSequence:reverseOutput(input)
+    self.output:resizeAs(input)
+    self.outputIndices:resize(input:size())
+    local T = input:size(1)
+    for x = 1, T do
+        self.outputIndices:narrow(1, x, 1):fill(T - x + 1)
+    end
+    self.output:gather(input, 1, self.outputIndices)
+end
+
+function SeqReverseSequence:updateOutput(input)
+    if (self.dim == 1) then
+        self:reverseOutput(input)
+    end
+    if (self.dim == 2) then
+        input = input:transpose(1, 2)
+        self:reverseOutput(input)
+        self.output = self.output:transpose(1, 2)
+    end
+    if (self.dim == 3) then
+        input = input:transpose(1, 3)
+        self:reverseOutput(input)
+        self.output = self.output:transpose(1, 3)
+    end
+    return self.output
+end
+
+function SeqReverseSequence:reverseGradOutput(gradOutput)
+    self.gradInput:resizeAs(gradOutput)
+    self.gradIndices:resize(gradOutput:size())
+    local T = gradOutput:size(1)
+    for x = 1, T do
+        self.gradIndices:narrow(1, x, 1):fill(T - x + 1)
+    end
+    self.gradInput:gather(gradOutput, 1, self.gradIndices)
+end
+
+function SeqReverseSequence:updateGradInput(inputTable, gradOutput)
+    if (self.dim == 1) then
+        self:reverseGradOutput(gradOutput)
+    end
+    if (self.dim == 2) then
+        gradOutput = gradOutput:transpose(1, 2)
+        self:reverseGradOutput(gradOutput)
+        self.gradInput = self.gradInput:transpose(1, 2)
+    end
+    if (self.dim == 3) then
+        gradOutput = gradOutput:transpose(1, 3)
+        self:reverseGradOutput(gradOutput)
+        self.gradInput = self.gradInput:transpose(1, 3)
+    end
+    return self.gradInput
+end

--- a/init.lua
+++ b/init.lua
@@ -46,6 +46,8 @@ torch.include('rnn', 'RecurrentAttention.lua')
 
 -- sequencer + recurrent modules
 torch.include('rnn', 'SeqLSTM.lua')
+torch.include('rnn', 'SeqReverseSequence.lua')
+torch.include('rnn', 'SeqBRNN.lua')
 
 -- recurrent criterions:
 torch.include('rnn', 'SequencerCriterion.lua')

--- a/test/test.lua
+++ b/test/test.lua
@@ -4721,12 +4721,13 @@ function rnntest.BRNNBatchFirstTest()
 
    local input = torch.rand(1, 5, 5)
    local output = brnn:forward(input)
-   local concatTable = brnn.modules[1]:get(1)
+   local concatTable = brnn.modules[1]:get(2)
    local fwd = concatTable:get(1) -- get SeqLSTM fwd.
    local bwd = concatTable:get(2):get(2) -- get SeqLSTM bwd.
    fwd:clearState()
    bwd:clearState()
 
+   input = input:transpose(1,2) -- Manually transpose the input.
    local fwdOutput = fwd:forward(input)
 
    local reverseSequence = nn.SeqReverseSequence(1)
@@ -4736,6 +4737,7 @@ function rnntest.BRNNBatchFirstTest()
    local bwdOutput = reverseSequence:forward(bwdOutput)
 
    local expectedOutput = nn.JoinTable(3):forward({fwdOutput, bwdOutput})
+   local expectedOutput = expectedOutput:transpose(1,2) -- Undo transpose to input.
    mytester:assertTensorEq(expectedOutput, output, 0)
 end
 


### PR DESCRIPTION
Hey!

I've added BRNN support similar to the PR torch-rnn and modified the code to suit the RNN structure, hopefully it looks good and is useful!

I've made the BRNN hardcode to use the SeqLSTM since it is the only supported module at the current stage, let me know if that's logical. 

One issue I'm having however is that this variable gives me issues upon clearing state in SeqLSTM, thus in the current state the tests fail:

```
function SeqLSTM:clearState()
   self.cell:set()
   self.gates:set()
   self.buffer1:set()
   self.buffer2:set()
   self.buffer3:set()
   self.grad_a_buffer:set()

   self.grad_c0:set()
   self.grad_h0:set()
   self.grad_x:set()
   self._grad_x:set() -- This variable until backward is call is nil
   self.output:set()
   self._output:set()
   self.gradInput = nil
end
```

I'm not entirely sure but is that not a duplicate of self.grad_x? Replacing all instances of _grad_x with self.grad_x and removing it seems to fix it but just wanted to check.

Finally how are the names looking? Hopefully the names of the brnn modules are alright. If you are happy with it all I'll update docs as well. Let me know of any feedback, cheers!
